### PR TITLE
Fixed typo in error message when master cannot be reached

### DIFF
--- a/include/misc.php
+++ b/include/misc.php
@@ -26,7 +26,7 @@ function findAllUsers($batch) {
     $retval = cached($url, false, $ctx);
     $json = json_decode($retval, true);
     if (!is_array($json)) {
-        error("Something happend to master");
+        error("Something happened to master");
     }
     if (isset($json["error"])) {
         error($json["error"]);


### PR DESCRIPTION
When master cannot be reached the error

> Something happend to master

is printed to the screen. This should be happened instead.
