### PR TITLE
Redirect to short URI on dropdown select

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -11,7 +11,7 @@ $('input.search').autocomplete({
     minChars:2, 
     maxHeight:400,
     fnFormatResult: fnFormatSearchResult,
-    onSelect: function(value, data){ window.location = "?username=" + users[value]["username"]; },
+    onSelect: function(value, data){ window.location = "/" + users[value]["username"]; },
     lookup: lookup
 });
 


### PR DESCRIPTION
When you are on e.g. `http://people.php.net/dm` and select `krakjoe` from dropdown/search you are redirected to `http://people.php.net/dm?username=krakjoe` instead of `http://people.php.net/krakjoe`, it works as-is but should be proper 😊 