### PR TITLE
Cache fetches for 1 day instead of 1 week

### DIFF
--- a/include/misc.php
+++ b/include/misc.php
@@ -67,7 +67,7 @@ function cached($url, $options = false, $ctx = null)
     $user = sha1($url);
 
     $tmpfile = $tmpdir . "/" . $user;
-    if (file_exists($tmpfile) && filemtime($tmpfile) > strtotime("-1 week")) {
+    if (file_exists($tmpfile) && filemtime($tmpfile) > strtotime("-1 day")) {
         return file_get_contents($tmpfile);
     }
     $content = file_get_contents($url, $options, $ctx);


### PR DESCRIPTION
Shorten the time between cache refreshes for files fetch from remote machines.  This reduces the delay between new information being available (e.g. user profile changes, karma updates) on the remote machine and reflected on the people site.

I kept it to 1 day to save too many people being affected by the slower response times while the cache is being updated.

Thoughts, ideas, complaints?

/cc @bjori 